### PR TITLE
Switch to pirates for babel-register. (#3670)

### DIFF
--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -13,9 +13,11 @@
     "home-or-tmp": "^3.0.0",
     "lodash": "^4.2.0",
     "mkdirp": "^0.5.1",
+    "pirates": "^3.0.1",
     "source-map-support": "^0.4.2"
   },
   "devDependencies": {
-    "decache": "^4.1.0"
+    "decache": "^4.1.0",
+    "default-require-extensions": "^1.0.0"
   }
 }

--- a/packages/babel-register/test/__data__/es2015.js
+++ b/packages/babel-register/test/__data__/es2015.js
@@ -1,0 +1,3 @@
+import a from "assert";
+
+export default () => { a.foo(); return "b"; };

--- a/packages/babel-register/test/cache.js
+++ b/packages/babel-register/test/cache.js
@@ -1,0 +1,84 @@
+import { expect } from "chai";
+import fs from "fs";
+import path from "path";
+import decache from "decache";
+
+const testCacheFilename = path.join(__dirname, ".babel");
+const oldBabelDisableCacheValue = process.env.BABEL_DISABLE_CACHE;
+
+process.env.BABEL_CACHE_PATH = testCacheFilename;
+delete process.env.BABEL_DISABLE_CACHE;
+
+function writeCache(data) {
+  if (typeof data === "object") {
+    data = JSON.stringify(data);
+  }
+
+  fs.writeFileSync(testCacheFilename, data);
+}
+
+function cleanCache() {
+
+  try {
+    fs.unlinkSync(testCacheFilename);
+  } catch (e) {
+    // It is convenient to always try to clear
+  }
+}
+
+function resetCache() {
+  process.env.BABEL_CACHE_PATH = null;
+  process.env.BABEL_DISABLE_CACHE = oldBabelDisableCacheValue;
+}
+
+describe("babel register", () => {
+
+  describe("cache", () => {
+    let load, get, save;
+
+    beforeEach(() => {
+      // Since lib/cache is a singleton we need to fully reload it
+      decache("../lib/cache");
+      const cache = require("../lib/cache");
+
+      load = cache.load;
+      get = cache.get;
+      save = cache.save;
+    });
+
+    afterEach(cleanCache);
+    after(resetCache);
+
+    it("should load and get cached data", () => {
+      writeCache({ foo: "bar" });
+
+      load();
+
+      expect(get()).to.be.an("object");
+      expect(get()).to.deep.equal({ foo: "bar" });
+    });
+
+    it("should load and get an object with no cached data", () => {
+      load();
+
+      expect(get()).to.be.an("object");
+      expect(get()).to.deep.equal({});
+    });
+
+    it("should load and get an object with invalid cached data", () => {
+      writeCache("foobar");
+
+      load();
+
+      expect(get()).to.be.an("object");
+      expect(get()).to.deep.equal({});
+    });
+
+    it("should create the cache on save", () => {
+      save();
+
+      expect(fs.existsSync(testCacheFilename)).to.be.true;
+      expect(get()).to.deep.equal({});
+    });
+  });
+});


### PR DESCRIPTION
* Switch to pirates for babel-register.

Pirates is a simple module that enables easy require hooking. It makes sure that your require hook works properly. It also makes the implimentation of babel-register a lot simpler.

For more on pirates: http://ariporad.link/piratesjs

* Use modified version of pirates.

* Switch back to stable version

* Initial tests for babel-register

* Fix tests to work in new test env

* Fix for new ignore behaviour

* Update pirates to 3.0.1

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | `Fixes #1, Fixes #2` <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->
