### PR TITLE
Fix incorrect property ordering with obj rest spread on nested (#5685)

### DIFF
--- a/packages/babel-plugin-transform-object-rest-spread/src/index.js
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.js
@@ -117,14 +117,21 @@ export default function ({ types: t }) {
             }
 
             let ref = this.originalPath.node.init;
+            const refPropertyPath = [];
 
             path.findParent((path) => {
               if (path.isObjectProperty()) {
-                ref = t.memberExpression(ref, t.identifier(path.node.key.name));
+                refPropertyPath.unshift(path.node.key.name);
               } else if (path.isVariableDeclarator()) {
                 return true;
               }
             });
+
+            if (refPropertyPath.length) {
+              refPropertyPath.forEach((prop) => {
+                ref = t.memberExpression(ref, t.identifier(prop));
+              });
+            }
 
             const [ argument, callExpression ] = createObjectSpread(
               file,

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested-2/actual.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested-2/actual.js
@@ -1,0 +1,15 @@
+const test = {
+  foo: {
+    bar: {
+      baz: {
+        a: {
+          x: 1,
+          y: 2,
+          z: 3,
+        },
+      },
+    },
+  },
+};
+
+const { foo: { bar: { baz: { a: { x, ...other } } } } } = test;

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested-2/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested-2/expected.js
@@ -1,0 +1,16 @@
+const test = {
+  foo: {
+    bar: {
+      baz: {
+        a: {
+          x: 1,
+          y: 2,
+          z: 3
+        }
+      }
+    }
+  }
+};
+
+const { foo: { bar: { baz: { a: { x } } } } } = test,
+      other = babelHelpers.objectWithoutProperties(test.foo.bar.baz.a, ["x"]);

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested/actual.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested/actual.js
@@ -1,0 +1,10 @@
+const defunct = {
+  outer: {
+    inner: {
+      three: 'three',
+      four: 'four'
+    }
+  }
+}
+
+const { outer: { inner: { three, ...other } } } = defunct

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested/expected.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested/expected.js
@@ -1,0 +1,11 @@
+const defunct = {
+  outer: {
+    inner: {
+      three: 'three',
+      four: 'four'
+    }
+  }
+};
+
+const { outer: { inner: { three } } } = defunct,
+      other = babelHelpers.objectWithoutProperties(defunct.outer.inner, ['three']);


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | `Fixes #1, Fixes #2` <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->
