### PR TITLE
Correct the validator for ArrayPattern (#5722)

### DIFF
--- a/packages/babel-types/src/definitions/es2015.js
+++ b/packages/babel-types/src/definitions/es2015.js
@@ -29,7 +29,7 @@ defineType("ArrayPattern", {
   aliases: ["Pattern", "LVal"],
   fields: {
     elements: {
-      validate: chain(assertValueType("array"), assertEach(assertNodeType("Expression"))),
+      validate: chain(assertValueType("array"), assertEach(assertNodeType("Identifier", "Pattern", "RestElement"))),
     },
     decorators: {
       validate: chain(assertValueType("array"), assertEach(assertNodeType("Decorator"))),


### PR DESCRIPTION
The elements of the `elements` array should be either `Identifier`, `Pattern` or `RestElement`, but the validator was requiring `Expression`. It happened to work for `Identifier` since an `Identifier` is an `Expression`, but not for the other possible pattern elements.

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | `Fixes #1, Fixes #2` <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->
