### PR TITLE
Add tests for babel-generator (#5845)

### DIFF
--- a/packages/babel-generator/test/fixtures/flow/type-annotations/actual.js
+++ b/packages/babel-generator/test/fixtures/flow/type-annotations/actual.js
@@ -35,6 +35,8 @@ class Foo {
   get fooProp(): number {}
 }
 var numVal: number;
+var numVal: empty;
+var numVal: mixed;
 var numVal: number = otherNumVal;
 var a: { numVal: number };
 var a: { numVal: number; };

--- a/packages/babel-generator/test/fixtures/flow/type-annotations/expected.js
+++ b/packages/babel-generator/test/fixtures/flow/type-annotations/expected.js
@@ -35,6 +35,8 @@ class Foo {
   get fooProp(): number {}
 }
 var numVal: number;
+var numVal: empty;
+var numVal: mixed;
 var numVal: number = otherNumVal;
 var a: { numVal: number };
 var a: { numVal: number };


### PR DESCRIPTION
Added two tests for src/generators/flow.js that check if a value is of
type `empty` or `mixed`.

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Deprecations?            | 
| Spec Compliancy?         | 
| Tests Added/Pass?        | 
| Fixed Tickets            | `Fixes #1, Fixes #2` <!-- rm the quotes to link the issues -->
| License                  | MIT
| Doc PR                   | <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | 

<!-- Describe your changes below in as much detail as possible -->
