### PR TITLE
Fix #4840: Alias class prototype for methods in loose mode (#5560)

### DIFF
--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose-classCallCheck/with-constructor/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose-classCallCheck/with-constructor/expected.js
@@ -5,7 +5,9 @@ let A = function A() {
 let B = function () {
   function B() {}
 
-  B.prototype.b = function b() {
+  var _proto = B.prototype;
+
+  _proto.b = function b() {
     console.log('b');
   };
 

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/constructor-order/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/constructor-order/expected.js
@@ -1,5 +1,7 @@
 var x = function () {
-  x.prototype.f = function f() {
+  var _proto = x.prototype;
+
+  _proto.f = function f() {
     1;
     2;
     3;

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/literal-key/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/literal-key/expected.js
@@ -1,7 +1,9 @@
 var Foo = function () {
   function Foo() {}
 
-  Foo.prototype["bar"] = function bar() {};
+  var _proto = Foo.prototype;
+
+  _proto["bar"] = function bar() {};
 
   return Foo;
 }();

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-return-type-annotation/expected.js
@@ -2,7 +2,9 @@
 var C = function () {
   function C() {}
 
-  C.prototype.m = function m(x: number): string {
+  var _proto = C.prototype;
+
+  _proto.m = function m(x: number): string {
     return 'a';
   };
 

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-reuse-prototype/actual.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-reuse-prototype/actual.js
@@ -1,0 +1,5 @@
+class Test {
+  a() {}
+  static b() {}
+  c() {}
+}

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-reuse-prototype/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/loose/method-reuse-prototype/expected.js
@@ -1,0 +1,13 @@
+var Test = function () {
+  function Test() {}
+
+  var _proto = Test.prototype;
+
+  _proto.a = function a() {};
+
+  Test.b = function b() {};
+
+  _proto.c = function c() {};
+
+  return Test;
+}();

--- a/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T6755/expected.js
+++ b/packages/babel-plugin-transform-es2015-classes/test/fixtures/regression/T6755/expected.js
@@ -3,11 +3,13 @@
 var Example = function () {
   function Example() {}
 
-  Example.prototype.test1 = async function test1() {
+  var _proto = Example.prototype;
+
+  _proto.test1 = async function test1() {
     await Promise.resolve(2);
   };
 
-  Example.prototype.test2 =
+  _proto.test2 =
   /*#__PURE__*/
   regeneratorRuntime.mark(function test2() {
     return regeneratorRuntime.wrap(function test2$(_context) {

--- a/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-loose-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-flow-comments/test/fixtures/flow-comments/transformed-class-method-loose-return-type-annotation/expected.js
@@ -4,7 +4,9 @@
 var C = function () {
   function C() {}
 
-  C.prototype.m = function m(x
+  var _proto = C.prototype;
+
+  _proto.m = function m(x
   /*: number*/
   )
   /*: string*/

--- a/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-loose-return-type-annotation/expected.js
+++ b/packages/babel-plugin-transform-flow-strip-types/test/fixtures/regression/transformed-class-method-loose-return-type-annotation/expected.js
@@ -3,7 +3,9 @@
 var C = function () {
   function C() {}
 
-  C.prototype.m = function m(x) {
+  var _proto = C.prototype;
+
+  _proto.m = function m(x) {
     return 'a';
   };
 


### PR DESCRIPTION
* Fix #4840: Alias class prototype for methods in loose mode

* Cleanup

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | `Fixes #1, Fixes #2` <!-- rm the quotes to link the issues -->
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added/Pass?        | 
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

<!-- Describe your changes below in as much detail as possible -->
