### PR TITLE
Do not fix linting errors in precommit hooks (#6218)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "eslint --format=codeframe --fix --rulesdir='./eslint_rules'",
-      "git add"
+      "eslint --format=codeframe --rulesdir='./eslint_rules'"
     ]
   }
 }


### PR DESCRIPTION
It's just damn annoying. Supersedes #5908.

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | `Fixes #1, Fixes #2` <!-- rm the quotes to link the issues -->
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added/Pass?        | 
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

<!-- Describe your changes below in as much detail as possible -->
