### PR TITLE
Update upstream

### DIFF
--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -13,7 +13,7 @@ export default function(commander, filenames, opts) {
       base = undefined;
     }
     if (!util.isCompilableExtension(relative, commander.extensions)) {
-      return callback();
+      return process.nextTick(callback);
     }
 
     // remove extension and then append back on .js


### PR DESCRIPTION
…on-js files in babel-cli (#7320)

Maximum call stack occurs when you try to copy large number of non-js files using `babel-cli@7.0.0-beta.38` or `babel-cli@7.0.0-beta.39`

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | `Fixes #1, Fixes #2` <!-- rm the quotes to link the issues -->
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added/Pass?        | 
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

<!-- Describe your changes below in as much detail as possible -->
