### PR TITLE
update Libseccomp to tagged release

### DIFF
--- a/packages/babel-helpers/src/helpers.js
+++ b/packages/babel-helpers/src/helpers.js
@@ -1070,10 +1070,10 @@ helpers.classPrivateFieldLooseBase = helper("7.0.0-beta.0")`
 
 helpers.classPrivateFieldGet = helper("7.0.0-beta.0")`
   export default function _classPrivateFieldGet(receiver, privateMap) {
-    if (!privateMap.has(receiver)) {
+    var descriptor = privateMap.get(receiver);
+    if (!descriptor) {
       throw new TypeError("attempted to get private field on non-instance");
     }
-    var descriptor = privateMap.get(receiver);
     if (descriptor.get) {
       return descriptor.get.call(receiver);
     }
@@ -1083,10 +1083,10 @@ helpers.classPrivateFieldGet = helper("7.0.0-beta.0")`
 
 helpers.classPrivateFieldSet = helper("7.0.0-beta.0")`
   export default function _classPrivateFieldSet(receiver, privateMap, value) {
-    if (!privateMap.has(receiver)) {
+    var descriptor = privateMap.get(receiver);
+    if (!descriptor) {
       throw new TypeError("attempted to set private field on non-instance");
     }
-    var descriptor = privateMap.get(receiver);
     if (descriptor.set) {
       descriptor.set.call(receiver, value);
     } else {


### PR DESCRIPTION
No need to do the hash lookup twice. If the descriptor is not in the
WeakMap `get` returns `undefined`.

<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(can use an emoji 👍 ) -->
| ------------------------ | ---
| Fixed Issues             | `Fixes #1, Fixes #2` <!-- rm the quotes to link the issues -->
| Patch: Bug Fix?          | 
| Major: Breaking Change?  | 
| Minor: New Feature?      | 
| Tests Added/Pass?        | 
| Spec Compliancy?         | 
| License                  | MIT
| Doc PR                   | <!-- if yes, can add `[skip ci]` to your commit message to skip CI builds -->
| Any Dependency Changes?  | 

<!-- Describe your changes below in as much detail as possible -->
